### PR TITLE
Fixed missing tab

### DIFF
--- a/tasks/prerequisite.yml
+++ b/tasks/prerequisite.yml
@@ -8,5 +8,5 @@
     - 'group_vars/os_{{ ansible_os_family }}.yml'
 
 - set_fact:
-  steamcmd_manual: "{{ os_steamcmd_manual }}"
+    steamcmd_manual: "{{ os_steamcmd_manual }}"
   when: steamcmd_manual is undefined


### PR DESCRIPTION
This missing tab was causing steamcmd_manual var assignment to get skipped